### PR TITLE
fix: add batch_id as optional argument when creating invoice payment

### DIFF
--- a/trolley/invoice_payment_gateway.py
+++ b/trolley/invoice_payment_gateway.py
@@ -14,15 +14,19 @@ class InvoicePaymentGateway(object):
         self.config = config
 
     """ Creates a new Invoice Payment.  """
-    def create(self, body):
+    def create(self, body, batch_id=None):
         if body is None:
             raise InvalidFieldException("Body cannot be None.")
         if not isinstance(body, list):
             raise InvalidFieldException("Body must be of type list")
-        
+        if batch_id is not None and not isinstance(batch_id, str):
+            raise InvalidFieldException("Batch ID must be of type str")
+
         payload = {
             'ids' : body
         }
+        if batch_id is not None:
+            payload['batchId'] = batch_id
 
         endpoint = f'/v1/invoices/payment/create'
         response = trolley.Configuration.client(


### PR DESCRIPTION
Fixes: #30 

Add batch_id as optional argument when creating invoice payment.

Previously creating an invoice payment would always create a new batch


### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified

If you have questions, create a GitHub Issue in this repository.
