### PR TITLE
fix: release trolleyhq 1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup
 
 setup (
     name='trolleyhq',
-    version='1.1.0',
+    version='1.1.1',
     packages=["trolley", "trolley.exceptions", "trolley.utils", "trolley.types"],
     package_data={"trolley": ["ssl/*"]},
-    install_requires=['requests>=2.32.0'],
+    install_requires=['requests>=2.32.0', 'python-dotenv>=1.0.0'],
     python_requires='>=3.9',
     author='Trolley',
     author_email='developer-tools@trolley.com',

--- a/test/unit/testReleasePrep.py
+++ b/test/unit/testReleasePrep.py
@@ -87,7 +87,7 @@ class ReleasePrepTest(unittest.TestCase):
 
         self.assertEqual({"ok": True}, response)
         headers = request.call_args.kwargs["headers"]
-        self.assertEqual("python-sdk_1.1.0", headers["Trolley-Source"])
+        self.assertEqual("python-sdk_1.1.1", headers["Trolley-Source"])
         self.assertTrue(headers["Authorization"].startswith("prsign public:"))
 
     def test_gateway_exposes_generic_request_and_trust_alias(self):

--- a/trolley/__init__.py
+++ b/trolley/__init__.py
@@ -15,4 +15,4 @@ from trolley.types.invoice_payment import InvoicePayment
 from trolley.types.invoice_payment_part import InvoicePaymentPart
 from trolley.types.verification import Verification
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
## Summary
- Bumps the published package/version metadata to `trolleyhq==1.1.1`.
- Adds the missing `python-dotenv>=1.0.0` runtime dependency required by `trolley.configuration`.
- Updates the release-prep unit test to expect the `python-sdk_1.1.1` source header.